### PR TITLE
missing cap:round

### DIFF
--- a/scene.yaml
+++ b/scene.yaml
@@ -82,7 +82,7 @@ layers:
             draw:
                 flatlines:
                     outline:
-                        order: 352                
+                        order: 352
                         width: function () { return 3/16 * Math.log($zoom); }
 
         highway:

--- a/scene.yaml
+++ b/scene.yaml
@@ -124,6 +124,7 @@ layers:
             # default style
             draw:
                 flatlines:
+                    cap: round
                     color: [[13, [0.8, 0.8, 0.8]], [17, [1, 1, 1]]]
                     width: [[13, 0px], [14, 2px], [16, 2.5px], [19, 8m]]
                     outline:
@@ -156,6 +157,7 @@ layers:
                 flatlines:
                     color: [[15, [0.6, 0.6, 0.6]], [17, [0.8, 0.8, 0.8]]]
                     width: [[13, 0px], [14, 1.5px], [15, 10m]]
+                    cap: round
                     outline:
                         width: [[13, 0px], [14, .5px], [17, 1px]]
         path:
@@ -164,6 +166,7 @@ layers:
                 flatlines:
                     color: [0.8, 0.8, 0.8]
                     width: [[16, 0], [17, 3m]]
+                    cap: round
                     outline:
                         width: .1
 

--- a/scene.yaml
+++ b/scene.yaml
@@ -128,6 +128,7 @@ layers:
                     color: [[13, [0.8, 0.8, 0.8]], [17, [1, 1, 1]]]
                     width: [[13, 0px], [14, 2px], [16, 2.5px], [19, 8m]]
                     outline:
+                        cap: butt
                         width: [[12, 0px], [13, .5px], [15, 1px]]
             primary:
                 filter: { kind_detail: primary }
@@ -159,6 +160,7 @@ layers:
                     width: [[13, 0px], [14, 1.5px], [15, 10m]]
                     cap: round
                     outline:
+                        cap: butt
                         width: [[13, 0px], [14, .5px], [17, 1px]]
         path:
             filter: { kind: path }
@@ -168,6 +170,7 @@ layers:
                     width: [[16, 0], [17, 3m]]
                     cap: round
                     outline:
+                        cap: butt
                         width: .1
 
         z-order:


### PR DESCRIPTION
missing cap:round causes many glitches (effect like at https://github.com/tangrams/cinnabar-style/issues/36).

This PR should fix this (at least partially, it is not thoroughly tested - maybe there are still some missing cap:round),